### PR TITLE
Feat/assignment5

### DIFF
--- a/backend/matching-service/consumer/main.go
+++ b/backend/matching-service/consumer/main.go
@@ -22,14 +22,26 @@ func main() {
 	}
 	defer channelRabbitMQ.Close()
 
-	messages, err := channelRabbitMQ.Consume(
-		"MatchingService", // queue name
-		"",                // consumer
-		true,              // auto-ack
+	q, err := channelRabbitMQ.QueueDeclare(
+		"MatchingService", // name
+		true,              // durable
+		false,             // delete when unused
 		false,             // exclusive
-		false,             // no local
-		false,             // no wait
+		false,             // no-wait
 		nil,               // arguments
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	messages, err := channelRabbitMQ.Consume(
+		q.Name, // queue name
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no local
+		false,  // no wait
+		nil,    // arguments
 	)
 	if err != nil {
 		log.Println(err)

--- a/backend/matching-service/producer/main.go
+++ b/backend/matching-service/producer/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 	defer channelRabbitMQ.Close()
 
-	_, err = channelRabbitMQ.QueueDeclare(
+	q, err := channelRabbitMQ.QueueDeclare(
 		"MatchingService", // queue name
 		true,              // durable
 		false,             // auto delete
@@ -42,11 +42,11 @@ func main() {
 			Body:        []byte("hello"),
 		}
 		if err := channelRabbitMQ.Publish(
-			"",                // exchange
-			"MatchingService", // queue name
-			false,             // mandatory
-			false,             // immediate
-			message,           // message to publish
+			"",      // exchange
+			q.Name,  // queue name
+			false,   // mandatory
+			false,   // immediate
+			message, // message to publish
 		); err != nil {
 			return err
 		}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,10 +66,10 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-        test: rabbitmq-diagnostics -q ping
-        interval: 5s
-        timeout: 10s
-        retries: 5
+      test: [ "CMD", "nc", "-z", "rabbitmq", "5672" ]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   matching-producer:
     container_name: matching-producer
@@ -86,7 +86,7 @@ services:
       - ./backend/matching-service/producer:/usr/src/app
     depends_on:
       rabbitmq:
-          condition: service_healthy
+        condition: service_healthy
 
   matching-consumer:
     container_name: matching-consumer
@@ -103,7 +103,9 @@ services:
       - ./backend/matching-service/consumer:/usr/src/app
     depends_on:
       matching-producer:
-          condition: service_started
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
 
   # question-service:
   #     container_name: question-service


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Summary of PR

This PR still has quite a lot of bugs that are not fixed

1. Producer and consumer have to be started after rabbitmq starts. I tried `depends_on`, `healthcheck` and condition combined with `depends_on`, but none of these work. Feel free to suggest any workarounds. Now one has to manually force `main.go` to be buggy in order to recreate the binary through `air`.

2. Currently rabbitmq always throw `operation basic.consume caused a channel exception not_found: no queue 'MatchingService' in vhost '/'`. I believe it is due do bug#1 too. Thus even I have added the skeleton code, the queue is still not completely set up yet.

## Details

## [Optional] Screenshots, Recordings
