### PR TITLE
Fix Code and Language when user refresh/exits

### DIFF
--- a/frontend/app/collab/page.tsx
+++ b/frontend/app/collab/page.tsx
@@ -33,7 +33,8 @@ export default function Collab() {
   const [newMessage, setNewMessage] = useState('');
   const ws = useRef(null);
   const languages = LANGUAGES.slice(1)
-  const [currentLanguage, setCurrentLanguage] = useState(languages[11])
+  const [currentLanguage, setCurrentLanguage] = useState(LANGUAGES[10]);
+  const [isPartnerPresent, setIsPartnerPresent] = useState(true);
 
   useEffect(() => {
     window.addEventListener('popstate', exitRoom);
@@ -63,8 +64,10 @@ export default function Collab() {
         setCurrentLanguage(message.Content as Language);
         notifyWarning(`Editor's language has been changed to ${message.Content}`);
       } else if (message.Type === "exit") {
+        setIsPartnerPresent(false);
         notifyError(message.Content);
       } else {
+        setIsPartnerPresent(true);
         notifySuccess(message.Content);
       }
     }
@@ -83,6 +86,13 @@ export default function Collab() {
     dispatch(setIsLeaving(false));
     dispatch(setIsChatOpen(false));
   }, []);
+
+  useEffect(() => {
+    if (isPartnerPresent && ws.current.readyState) {
+      sendMessage(code, "code");
+      sendMessage(currentLanguage, "language");
+    } 
+  }, [isPartnerPresent])
 
   const sendMessage = (value : string, type : string) => {
     const message = {
@@ -113,6 +123,7 @@ export default function Collab() {
   };
 
   const handleEditorChange = (value: string, event) => {
+    setCode(value);
     sendMessage(value, "code");
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Summary of PR
As per title
## Details
When one user (User A) refreshes/exits then re-enter the room will the other user (User B) is still in the room,
the current state of the language and code from User B would be send over to User A.

## [Optional] Screenshots, Recordings

https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g13/assets/66376253/92818ea0-bc4c-433d-87e2-3120ec8c69d4


